### PR TITLE
[Fix #6] Use ‘outer-window-id’ instead of ‘window-id’

### DIFF
--- a/README.org
+++ b/README.org
@@ -36,13 +36,6 @@ configuring ~camcorder-recording-command~ and
 
 ** Troubleshooting
 
-On my machine, I noticed that the window-id Emacs reported 
-#+BEGIN_SRC emacs-lisp
-(format "%x"
-  (string-to-number
-   (frame-parameter (selected-frame) 'window-id)))
-#+END_SRC
-differed from the id that the WM reported with the =wminfo= utility. I
-added the variable =camcorder-window-id-offset= to correct that. The
-default value is -4, but you might need to increase or decrease that
-to make those two numbers match.
+If camcorder.el seems to pick an incorrect window id (differing from the
+one that =wminfo= returns), you can change =camcorder-window-id-offset= from its
+default value of 0.

--- a/camcorder.el
+++ b/camcorder.el
@@ -60,16 +60,9 @@
 ;; Troubleshooting
 ;; ───────────────
 ;;
-;;   On my machine, I noticed that the window-id Emacs reported
-;;   ┌────
-;;   │ (format "%x"
-;;   │   (string-to-number
-;;   │    (frame-parameter (selected-frame) 'window-id)))
-;;   └────
-;;   differed from the id that the WM reported with the `wminfo' utility. I
-;;   added the variable `camcorder-window-id-offset' to correct that. The
-;;   default value is -4, but you might need to increase or decrease that
-;;   to make those two numbers match.
+;;   If camcorder.el seems to pick an incorrect window id (differing from the
+;;   one that `wminfo' returns), you can change `camcorder-window-id-offset' from its
+;;   default value of 0.
 
 ;;; Code:
 
@@ -160,8 +153,11 @@ completely different conversion commands, if you know any."
                               (const :tag "Temporary intermediate file" temp-file)
                               (const :tag "Temporary intermediate dir" temp-dir)))))
 
-(defcustom window-id-offset -4
-  "Difference between Emacs' and X's window-id."
+(defcustom window-id-offset 0
+  "Difference between Emacs' and X's window-id.
+This variable should be mostly irrelevant; it was more useful
+when camcorder.el relied on `window-id' instead of
+`outer-window-id'."
   :type 'integer)
 
 (defcustom output-directory (expand-file-name "~/Videos")
@@ -354,7 +350,7 @@ Used on `camcorder-recording-command'."
 Increments the actual value by `window-id-offset'."
   (format "0x%x"
           (+ (string-to-number
-              (frame-parameter frame 'window-id))
+              (frame-parameter frame 'outer-window-id))
              window-id-offset)))
 
 )


### PR DESCRIPTION
This should make ‘camcorder-window-id-offset’ largely irrelevant.