### PR TITLE
Fix ffmpeg gif conversion command - no more artifacts

### DIFF
--- a/camcorder.el
+++ b/camcorder.el
@@ -111,6 +111,9 @@ Meaning of symbols:
 
 (defcustom gif-conversion-commands
   '(("ffmpeg"
+     "ffmpeg -i " input-file " -vf palettegen input.palette.png"
+     " && ffmpeg -i " input-file " -i input.palette.png -filter_complex paletteuse " gif-file)
+    ("ffmpeg (small size, but with artifacts)"
      "ffmpeg -i " input-file " -pix_fmt rgb24 -r 30 " gif-file)
     ("mplayer + imagemagick"
      "mkdir -p " temp-dir

--- a/camcorder.el
+++ b/camcorder.el
@@ -111,8 +111,11 @@ Meaning of symbols:
 
 (defcustom gif-conversion-commands
   '(("ffmpeg"
-     "ffmpeg -i " input-file " -vf palettegen input.palette.png"
-     " && ffmpeg -i " input-file " -i input.palette.png -filter_complex paletteuse " gif-file)
+     "mkdir -p " temp-dir
+     " && cd " temp-dir
+     " && ffmpeg -i " input-file " -vf palettegen input.palette.png"
+     " && ffmpeg -i " input-file " -i input.palette.png -filter_complex paletteuse " gif-file
+     "; rm -r " temp-dir)
     ("ffmpeg (small size, but with artifacts)"
      "ffmpeg -i " input-file " -pix_fmt rgb24 -r 30 " gif-file)
     ("mplayer + imagemagick"


### PR DESCRIPTION
Closes #5 

Implement the command @DamienCassou referenced in issue #5 as the default ffmpeg gif conversion command:

> $ ffmpeg -i input.ogv -vf palettegen input.palette.png
> $ ffmpeg -i input.ogv -i input.palette.png -filter_complex paletteuse input.gif

It also keeps the legacy command, in case people still want the small file size.

